### PR TITLE
Make necessary native APIs publicly accessible

### DIFF
--- a/module-ballerina-xsd/BalTool.toml
+++ b/module-ballerina-xsd/BalTool.toml
@@ -2,8 +2,8 @@
 id = "xsd"
 
 [[dependency]]
-path = "../xsd-core/build/libs/xsd-cli-1.0.1.jar"
+path = "../xsd-core/build/libs/xsd-cli-1.0.1-SNAPSHOT.jar"
 
 [[dependency]]
-path = "../xsd-core/build/libs/xsd-core-1.0.1.jar"
+path = "../xsd-core/build/libs/xsd-core-1.0.1-SNAPSHOT.jar"
 

--- a/module-ballerina-xsd/README.md
+++ b/module-ballerina-xsd/README.md
@@ -9,7 +9,7 @@ The Ballerina XSD Tool simplifies the generation of Ballerina record types from 
 Execute the command below to pull the XSD tool from Ballerina Central.
 
 ```bash
-$ bal tool pull xsd:1.0.1
+$ bal tool pull xsd:1.0.2
 ```
 
 ### Usage

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/Utils.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/Utils.java
@@ -55,7 +55,7 @@ public class Utils {
     private Utils() {
     }
 
-    static ModulePartNode generateModulePartNode(Map<String, ModuleMemberDeclarationNode> nodes,
+    public static ModulePartNode generateModulePartNode(Map<String, ModuleMemberDeclarationNode> nodes,
                                                  XSDVisitor xsdVisitor) throws Exception {
         NodeList<ModuleMemberDeclarationNode> moduleMembers = AbstractNodeFactory.createNodeList(nodes.values());
         NodeList<ImportDeclarationNode> imports = getImportDeclarations(xsdVisitor);

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
@@ -91,7 +91,7 @@ public final class XSDToRecord {
         processEnumerations(nodes, xsdVisitor.getEnumerationElements());
     }
 
-    private static void generateNodes(Element rootElement, Map<String, ModuleMemberDeclarationNode> nodes,
+    public static void generateNodes(Element rootElement, Map<String, ModuleMemberDeclarationNode> nodes,
                                       XSDVisitor xsdVisitor) throws Exception {
         for (Node childNode : VisitorUtils.asIterable(rootElement.getChildNodes())) {
             if (childNode.getNodeType() != Node.ELEMENT_NODE) {
@@ -112,7 +112,7 @@ public final class XSDToRecord {
         }
     }
 
-    private static void processRootElements(Map<String, ModuleMemberDeclarationNode> nodes,
+    public static void processRootElements(Map<String, ModuleMemberDeclarationNode> nodes,
                                             Map<String, String> rootElements) {
         for (Map.Entry<String, String> entry : rootElements.entrySet()) {
             String element = entry.getKey();
@@ -126,7 +126,7 @@ public final class XSDToRecord {
         }
     }
 
-    private static void processNestedElements(Map<String, ModuleMemberDeclarationNode> nodes,
+    public static void processNestedElements(Map<String, ModuleMemberDeclarationNode> nodes,
                                               Map<String, String> nestedElements) {
         for (Map.Entry<String, String> entry : nestedElements.entrySet()) {
             String element = entry.getKey();
@@ -136,7 +136,7 @@ public final class XSDToRecord {
         }
     }
 
-    private static void processNameResolvers(Map<String, ModuleMemberDeclarationNode> nodes,
+    public static void processNameResolvers(Map<String, ModuleMemberDeclarationNode> nodes,
                                              Map<String, String> nameResolvers) {
         for (Map.Entry<String, String> entry : nameResolvers.entrySet()) {
             String element = entry.getKey();
@@ -148,7 +148,7 @@ public final class XSDToRecord {
         }
     }
 
-    private static void processExtensions(Map<String, ModuleMemberDeclarationNode> nodes, XSDVisitor xsdVisitor) {
+    public static void processExtensions(Map<String, ModuleMemberDeclarationNode> nodes, XSDVisitor xsdVisitor) {
         Map<String, String> extensions = xsdVisitor.getExtensions();
         for (Map.Entry<String, String> entry : extensions.entrySet()) {
             String key = entry.getKey();

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/VisitorUtils.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/VisitorUtils.java
@@ -83,13 +83,13 @@ public final class VisitorUtils {
     public static final String XMLDATA_NAMESPACE = "@xmldata:Namespace";
     public static final String URI = "uri";
     public static final String DURATION = "duration";
+    public static final String UNDERSCORE = "_";
     private static final String INVALID_CHARS_PATTERN = ".*[!@$%^&*()_\\-|/\\\\\\s\\d].*";
     private static final String DIGIT_PATTERN = ".*\\d.*";
     private static final String STARTS_WITH_DIGIT_PATTERN = "^\\d.*";
     private static final String SLASH_PATTERN = "[/\\\\]";
     private static final String WHITESPACE_PATTERN = "\\s";
     private static final String SPECIAL_CHARS_PATTERN = "[!@$%^&*()_\\-|]";
-    private static final String UNDERSCORE = "_";
 
     public static String addNamespace(XSDVisitorImpl xsdVisitor, String namespace) {
         xsdVisitor.addImports(BALLERINA_XML_DATA_MODULE);


### PR DESCRIPTION
## Purpose
> The WSDL tool requires some APIs in the `xsd-core` component which are not publicly accessible at the moment. This to make those APIs publicly accessible via the `xsd-core` dependency