### PR TITLE
Support handling `attributeFormDefault` and `elementFormDefault` attributes in XSD specs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=1.3.1-SNAPSHOT
+version=1.4.0-SNAPSHOT
 
 # Dependencies
 ballerinaLangVersion=2201.11.0

--- a/module-ballerina-xsd/BalTool.toml
+++ b/module-ballerina-xsd/BalTool.toml
@@ -2,8 +2,8 @@
 id = "xsd"
 
 [[dependency]]
-path = "../xsd-cli/build/libs/xsd-cli-1.3.1-SNAPSHOT.jar"
+path = "../xsd-cli/build/libs/xsd-cli-1.4.0-SNAPSHOT.jar"
 
 [[dependency]]
-path = "../xsd-core/build/libs/xsd-core-1.3.1-SNAPSHOT.jar"
+path = "../xsd-core/build/libs/xsd-core-1.4.0-SNAPSHOT.jar"
 

--- a/module-ballerina-xsd/Ballerina.toml
+++ b/module-ballerina-xsd/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.11.0"
 org = "ballerina"
 name = "xsdtool"
-version = "1.3.1"
+version = "1.4.0"
 authors = ["Ballerina"]
 keywords = ["xsd", "xsd-tool"]
 repository = "https://github.com/ballerina-platform/xsd-tools"

--- a/module-ballerina-xsd/Dependencies.toml
+++ b/module-ballerina-xsd/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.11.0"
 [[package]]
 org = "ballerina"
 name = "xsdtool"
-version = "1.3.1"
+version = "1.4.0"
 modules = [
 	{org = "ballerina", packageName = "xsdtool", moduleName = "xsdtool"}
 ]

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
@@ -87,7 +87,7 @@ public final class XSDToRecord {
     public static final String EQUAL = "=";
     public static final String TARGET_NAMESPACE = "targetNamespace";
     public static final String ELEMENT_FORM_DEFAULT = "elementFormDefault";
-    public static final String UNQUALIFIED = "unqualified";
+    public static final String QUALIFIED = "qualified";
 
     private static final String CONTENT_FIELD = "\\#content";
     public static final String FILE_EXTENSION = ".bal";
@@ -132,7 +132,7 @@ public final class XSDToRecord {
                     throw new Exception(INVALID_XSD_FORMAT_ERROR);
                 }
                 xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
-                xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
+                xsdVisitor.setElementFormDefault(QUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
                 xsdVisitor.clearImports();
                 processNodeList(rootElement, nodes, xsdVisitor);
                 handleExistingTypes(documents, typesMap, xsdVisitor, existingTypes, document, nodes);
@@ -185,7 +185,7 @@ public final class XSDToRecord {
                     throw new Exception(INVALID_XSD_FORMAT_ERROR);
                 }
                 xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
-                xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
+                xsdVisitor.setElementFormDefault(QUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
                 Map<String, MemberNode> nodes = new LinkedHashMap<>();
                 xsdVisitor.clearImports();
                 processNodeList(rootElement, nodes, xsdVisitor);
@@ -222,7 +222,7 @@ public final class XSDToRecord {
                     throw new Exception(INVALID_XSD_FORMAT_ERROR);
                 }
                 xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
-                xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
+                xsdVisitor.setElementFormDefault(QUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
                 Map<String, MemberNode> nodes = new LinkedHashMap<>();
                 xsdVisitor.clearImports();
                 processNodeList(rootElement, nodes, xsdVisitor);
@@ -254,7 +254,7 @@ public final class XSDToRecord {
             throw new Exception(INVALID_XSD_FORMAT_ERROR);
         }
         xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
-        xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
+        xsdVisitor.setElementFormDefault(QUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
         Map<String, MemberNode> nodes = new LinkedHashMap<>();
         processNodeList(rootElement, nodes, xsdVisitor);
         return nodes;
@@ -270,7 +270,7 @@ public final class XSDToRecord {
      */
     public static void generateNodes(Element rootElement, Map<String, MemberNode> nodes,
                                      XSDVisitor xsdVisitor) throws Exception {
-        xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
+        xsdVisitor.setElementFormDefault(QUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
         for (Node childNode : Utils.asIterable(rootElement.getChildNodes())) {
             if (childNode.getNodeType() != Node.ELEMENT_NODE) {
                 continue;

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
@@ -87,6 +87,7 @@ public final class XSDToRecord {
     public static final String EQUAL = "=";
     public static final String TARGET_NAMESPACE = "targetNamespace";
     public static final String ELEMENT_FORM_DEFAULT = "elementFormDefault";
+    public static final String ATTRIBUTE_FORM_DEFAULT = "attributeFormDefault";
     public static final String QUALIFIED = "qualified";
 
     private static final String CONTENT_FIELD = "\\#content";
@@ -133,6 +134,7 @@ public final class XSDToRecord {
                 }
                 xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
                 xsdVisitor.setElementFormDefault(QUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
+                xsdVisitor.setAttributeFormDefault(QUALIFIED.equals(rootElement.getAttribute(ATTRIBUTE_FORM_DEFAULT)));
                 xsdVisitor.clearImports();
                 processNodeList(rootElement, nodes, xsdVisitor);
                 handleExistingTypes(documents, typesMap, xsdVisitor, existingTypes, document, nodes);
@@ -255,6 +257,7 @@ public final class XSDToRecord {
         }
         xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
         xsdVisitor.setElementFormDefault(QUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
+        xsdVisitor.setAttributeFormDefault(QUALIFIED.equals(rootElement.getAttribute(ATTRIBUTE_FORM_DEFAULT)));
         Map<String, MemberNode> nodes = new LinkedHashMap<>();
         processNodeList(rootElement, nodes, xsdVisitor);
         return nodes;
@@ -271,6 +274,7 @@ public final class XSDToRecord {
     public static void generateNodes(Element rootElement, Map<String, MemberNode> nodes,
                                      XSDVisitor xsdVisitor) throws Exception {
         xsdVisitor.setElementFormDefault(QUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
+        xsdVisitor.setAttributeFormDefault(QUALIFIED.equals(rootElement.getAttribute(ATTRIBUTE_FORM_DEFAULT)));
         for (Node childNode : Utils.asIterable(rootElement.getChildNodes())) {
             if (childNode.getNodeType() != Node.ELEMENT_NODE) {
                 continue;

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
@@ -273,6 +273,7 @@ public final class XSDToRecord {
      */
     public static void generateNodes(Element rootElement, Map<String, MemberNode> nodes,
                                      XSDVisitor xsdVisitor) throws Exception {
+        xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
         xsdVisitor.setElementFormDefault(QUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
         xsdVisitor.setAttributeFormDefault(QUALIFIED.equals(rootElement.getAttribute(ATTRIBUTE_FORM_DEFAULT)));
         for (Node childNode : Utils.asIterable(rootElement.getChildNodes())) {

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/XSDToRecord.java
@@ -86,6 +86,8 @@ public final class XSDToRecord {
     public static final String XMLDATA_NAME_ANNOTATION = "@xmldata:Name {value: \"%s\"}";
     public static final String EQUAL = "=";
     public static final String TARGET_NAMESPACE = "targetNamespace";
+    public static final String ELEMENT_FORM_DEFAULT = "elementFormDefault";
+    public static final String UNQUALIFIED = "unqualified";
 
     private static final String CONTENT_FIELD = "\\#content";
     public static final String FILE_EXTENSION = ".bal";
@@ -130,6 +132,7 @@ public final class XSDToRecord {
                     throw new Exception(INVALID_XSD_FORMAT_ERROR);
                 }
                 xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
+                xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
                 xsdVisitor.clearImports();
                 processNodeList(rootElement, nodes, xsdVisitor);
                 handleExistingTypes(documents, typesMap, xsdVisitor, existingTypes, document, nodes);
@@ -182,8 +185,8 @@ public final class XSDToRecord {
                     throw new Exception(INVALID_XSD_FORMAT_ERROR);
                 }
                 xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
+                xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
                 Map<String, MemberNode> nodes = new LinkedHashMap<>();
-                xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
                 xsdVisitor.clearImports();
                 processNodeList(rootElement, nodes, xsdVisitor);
                 handleExistingTypes(typesMap, xsdVisitor, existingTypes, nodes);
@@ -219,8 +222,8 @@ public final class XSDToRecord {
                     throw new Exception(INVALID_XSD_FORMAT_ERROR);
                 }
                 xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
+                xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
                 Map<String, MemberNode> nodes = new LinkedHashMap<>();
-                xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
                 xsdVisitor.clearImports();
                 processNodeList(rootElement, nodes, xsdVisitor);
                 handleExistingTypes(typesMap, xsdVisitor, existingTypes, nodes);
@@ -251,6 +254,7 @@ public final class XSDToRecord {
             throw new Exception(INVALID_XSD_FORMAT_ERROR);
         }
         xsdVisitor.setTargetNamespace(rootElement.getAttribute(TARGET_NAMESPACE));
+        xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
         Map<String, MemberNode> nodes = new LinkedHashMap<>();
         processNodeList(rootElement, nodes, xsdVisitor);
         return nodes;
@@ -266,6 +270,7 @@ public final class XSDToRecord {
      */
     public static void generateNodes(Element rootElement, Map<String, MemberNode> nodes,
                                      XSDVisitor xsdVisitor) throws Exception {
+        xsdVisitor.setElementFormDefault(!UNQUALIFIED.equals(rootElement.getAttribute(ELEMENT_FORM_DEFAULT)));
         for (Node childNode : Utils.asIterable(rootElement.getChildNodes())) {
             if (childNode.getNodeType() != Node.ELEMENT_NODE) {
                 continue;

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitor.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitor.java
@@ -52,6 +52,8 @@ public interface XSDVisitor {
     String getTargetNamespace();
     void setElementFormDefault(boolean qualified);
     boolean isElementFormQualified();
+    void setAttributeFormDefault(boolean qualified);
+    boolean isAttributeFormQualified();
     ArrayList<String> getImports();
     Map<String, String> getRootElements();
     Map<String, XSDElement> getExtensions();

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitor.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitor.java
@@ -50,6 +50,8 @@ public interface XSDVisitor {
     String visit(Choice choice) throws Exception;
     void setTargetNamespace(String targetNamespace);
     String getTargetNamespace();
+    void setElementFormDefault(boolean qualified);
+    boolean isElementFormQualified();
     ArrayList<String> getImports();
     Map<String, String> getRootElements();
     Map<String, XSDElement> getExtensions();

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
@@ -152,6 +152,7 @@ public class XSDVisitorImpl implements XSDVisitor {
     private final ArrayList<String> complexTypeNames = new ArrayList<>();
     private final ArrayList<String> elementNames = new ArrayList<>();
     private String targetNamespace;
+    private boolean elementFormQualified = true;
 
     // Metadata to keep resolved name to original name
     private final Map<String, String> resolvedNameMeta = new HashMap<>();
@@ -357,6 +358,16 @@ public class XSDVisitorImpl implements XSDVisitor {
         return this.targetNamespace;
     }
 
+    @Override
+    public void setElementFormDefault(boolean qualified) {
+        this.elementFormQualified = qualified;
+    }
+
+    @Override
+    public boolean isElementFormQualified() {
+        return this.elementFormQualified;
+    }
+
     private Node visitNestedElements(Node node, Node nameNode, Node typeNode) throws Exception {
         if (typeNode == null && node.hasChildNodes()) {
             typeNode = nameNode;
@@ -515,7 +526,9 @@ public class XSDVisitorImpl implements XSDVisitor {
         StringBuilder childNodeBuilder = new StringBuilder();
         processChildChoiceNodes(childNodes, childNodeBuilder);
         this.addImports(BALLERINA_XML_DATA_MODULE);
-        stringBuilder.append(addNamespace(this, getTargetNamespace()));
+        if (elementFormQualified) {
+            stringBuilder.append(addNamespace(this, getTargetNamespace()));
+        }
         String choiceName = applyChoiceAnnotation(builder, node);
         stringBuilder.append(PUBLIC).append(WHITESPACE).append(TYPE).append(WHITESPACE).append(choiceName);
         stringBuilder.append(WHITESPACE).append(RECORD).append(WHITESPACE).append(OPEN_BRACES).append(VERTICAL_BAR);
@@ -541,7 +554,9 @@ public class XSDVisitorImpl implements XSDVisitor {
         StringBuilder childNodeBuilder = new StringBuilder();
         processChildNodes(isOptional, childNodes, childNodeBuilder);
         this.addImports(BALLERINA_XML_DATA_MODULE);
-        stringBuilder.append(addNamespace(this, getTargetNamespace()));
+        if (elementFormQualified) {
+            stringBuilder.append(addNamespace(this, getTargetNamespace()));
+        }
         boolean allChildrenOptional = areAllChildrenOptional(childNodes);
         String sequenceName = applySequenceAnnotation(node, builder, allChildrenOptional);
         generateSequenceType(stringBuilder, childNodeBuilder, sequenceName);
@@ -690,7 +705,9 @@ public class XSDVisitorImpl implements XSDVisitor {
             } else if (childNode.getLocalName().equals(CHOICE)) {
                 stringBuilder.append(visit(new Choice(childNode)));
             } else {
-                stringBuilder.append(addNamespace(this, getTargetNamespace()));
+                if (elementFormQualified) {
+                    stringBuilder.append(addNamespace(this, getTargetNamespace()));
+                }
                 if (childNode.hasChildNodes()) {
                     StringBuilder childNodeBuilder = new StringBuilder();
                     processChildNode(childNode, childNodeBuilder);
@@ -757,7 +774,9 @@ public class XSDVisitorImpl implements XSDVisitor {
             }
             order++;
             component.get().setOptional(isOptional);
-            stringBuilder.append(addNamespace(this, getTargetNamespace()));
+            if (elementFormQualified) {
+                stringBuilder.append(addNamespace(this, getTargetNamespace()));
+            }
             String orderAnnotation = XMLDATA_ORDER + WHITESPACE + OPEN_BRACES + VALUE + COLON + order + CLOSE_BRACES;
             stringBuilder.append(orderAnnotation);
             if (component.get().getKind() != Kind.SEQUENCE && component.get().getKind() != Kind.CHOICE) {
@@ -777,7 +796,9 @@ public class XSDVisitorImpl implements XSDVisitor {
             stringBuilder.append(component.get().accept(this));
         }
         if (order == 0) {
-            stringBuilder.append(addNamespace(this, getTargetNamespace()));
+            if (elementFormQualified) {
+                stringBuilder.append(addNamespace(this, getTargetNamespace()));
+            }
             stringBuilder.append(XMLDATA_ORDER + WHITESPACE + OPEN_BRACES + VALUE + COLON + ONE + CLOSE_BRACES);
             stringBuilder.append(STRING).append(WHITESPACE).append(CONTENT_FIELD)
                 .append(QUESTION_MARK).append(SEMICOLON);
@@ -793,7 +814,9 @@ public class XSDVisitorImpl implements XSDVisitor {
             }
             component.get().setSubType(true);
             component.get().setOptional(isOptional);
-            stringBuilder.append(addNamespace(this, getTargetNamespace()));
+            if (elementFormQualified) {
+                stringBuilder.append(addNamespace(this, getTargetNamespace()));
+            }
             stringBuilder.append(component.get().accept(this));
         }
     }
@@ -804,7 +827,9 @@ public class XSDVisitorImpl implements XSDVisitor {
         if (component.isPresent()) {
             component.get().setSubType(true);
             component.get().setOptional(false);
-            stringBuilder.append(addNamespace(this, getTargetNamespace()));
+            if (elementFormQualified) {
+                stringBuilder.append(addNamespace(this, getTargetNamespace()));
+            }
             stringBuilder.append(component.get().accept(this));
         }
     }

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
@@ -152,7 +152,7 @@ public class XSDVisitorImpl implements XSDVisitor {
     private final ArrayList<String> complexTypeNames = new ArrayList<>();
     private final ArrayList<String> elementNames = new ArrayList<>();
     private String targetNamespace;
-    private boolean elementFormQualified = true;
+    private boolean elementFormQualified = false;
 
     // Metadata to keep resolved name to original name
     private final Map<String, String> resolvedNameMeta = new HashMap<>();

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
@@ -754,8 +754,7 @@ public class XSDVisitorImpl implements XSDVisitor {
                     stringBuilder.append(addNamespace(this, getTargetNamespace()));
                 }
                 if (childNode.hasChildNodes()) {
-                    StringBuilder childNodeBuilder = new StringBuilder();
-                    processChildNode(childNode, childNodeBuilder);
+                    processChildNode(childNode);
                 }
                 Node nameNode = childNode.getAttributes().getNamedItem(NAME);
                 Node typeNode = childNode.getAttributes().getNamedItem(TYPE);
@@ -866,16 +865,12 @@ public class XSDVisitorImpl implements XSDVisitor {
         }
     }
 
-    private void processChildNode(Node childNode,
-                                  StringBuilder stringBuilder) throws Exception {
+    private void processChildNode(Node childNode) throws Exception {
         Optional<XSDComponent> component = XSDFactory.generateComponents(childNode);
         if (component.isPresent()) {
             component.get().setSubType(true);
             component.get().setOptional(false);
-            if (elementFormQualified) {
-                stringBuilder.append(addNamespace(this, getTargetNamespace()));
-            }
-            stringBuilder.append(component.get().accept(this));
+            component.get().accept(this);
         }
     }
 

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
@@ -153,6 +153,7 @@ public class XSDVisitorImpl implements XSDVisitor {
     private final ArrayList<String> elementNames = new ArrayList<>();
     private String targetNamespace;
     private boolean elementFormQualified = false;
+    private boolean attributeFormQualified = false;
 
     // Metadata to keep resolved name to original name
     private final Map<String, String> resolvedNameMeta = new HashMap<>();
@@ -368,6 +369,16 @@ public class XSDVisitorImpl implements XSDVisitor {
         return this.elementFormQualified;
     }
 
+    @Override
+    public void setAttributeFormDefault(boolean qualified) {
+        this.attributeFormQualified = qualified;
+    }
+
+    @Override
+    public boolean isAttributeFormQualified() {
+        return this.attributeFormQualified;
+    }
+
     private Node visitNestedElements(Node node, Node nameNode, Node typeNode) throws Exception {
         if (typeNode == null && node.hasChildNodes()) {
             typeNode = nameNode;
@@ -416,6 +427,9 @@ public class XSDVisitorImpl implements XSDVisitor {
         Node typeNode = attribute.getAttributes().getNamedItem(TYPE);
         if (nameNode == null) {
             throw new Exception(String.format(ATTRIBUTE_NOT_FOUND_ERROR, NAME));
+        }
+        if (attributeFormQualified) {
+            builder.append(addNamespace(this, getTargetNamespace()));
         }
         builder.append(ATTRIBUTE_ANNOTATION).append(WHITESPACE);
         Node fixedNode = attribute.getAttributes().getNamedItem(FIXED);

--- a/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
+++ b/xsd-core/src/main/java/io/ballerina/xsd/core/visitor/XSDVisitorImpl.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.ballerina.xsd.core.Utils.resolveNameConflicts;
+import static io.ballerina.xsd.core.XSDToRecord.QUALIFIED;
 import static io.ballerina.xsd.core.XSDToRecord.STRICT_ANY_PLACEHOLDER;
 import static io.ballerina.xsd.core.diagnostic.DiagnosticMessage.xsdToBallerinaError;
 import static io.ballerina.xsd.core.visitor.Utils.ANYDATA;
@@ -140,6 +141,7 @@ public class XSDVisitorImpl implements XSDVisitor {
     public static final String PROCESS_CONTENTS = "processContents";
     public static final String ANY_ANNOTATION = "@xmldata:Any";
     public static final String COMPLEX_CONTENT = "complexContent";
+    public static final String FORM = "form";
     private final ArrayList<String> imports = new ArrayList<>();
     private final Map<String, XSDElement> extensions = new LinkedHashMap<>();
     private final Map<String, String> rootElements = new LinkedHashMap<>();
@@ -244,7 +246,14 @@ public class XSDVisitorImpl implements XSDVisitor {
         }
         Node node = element.getNode();
         StringBuilder builder = new StringBuilder();
-        builder.append(addNamespace(this, getTargetNamespace()));
+        Node parentElement = node.getParentNode();
+        Node formNode = parentElement != null && parentElement.getAttributes() != null
+                ? parentElement.getAttributes().getNamedItem(FORM) : null;
+        boolean qualified = !element.isNestedElement()
+                || (formNode != null ? QUALIFIED.equals(formNode.getNodeValue()) : elementFormQualified);
+        if (qualified) {
+            builder.append(addNamespace(this, getTargetNamespace()));
+        }
         builder.append(PUBLIC).append(WHITESPACE).append(TYPE).append(WHITESPACE);
         setTypeDefinition(element, node, builder);
         Node nameNode = node.getAttributes().getNamedItem(NAME);
@@ -420,6 +429,28 @@ public class XSDVisitorImpl implements XSDVisitor {
         return typeNode;
     }
 
+    private boolean isAttributeQualified(Node attributeNode) {
+        Node formNode = attributeNode.getAttributes() != null
+                ? attributeNode.getAttributes().getNamedItem(FORM) : null;
+        if (formNode != null) {
+            return QUALIFIED.equals(formNode.getNodeValue());
+        }
+        return attributeFormQualified;
+    }
+
+    private boolean isElementQualified(Node elementNode) {
+        if (elementNode.getAttributes() != null) {
+            if (elementNode.getAttributes().getNamedItem(REF) != null) {
+                return true;
+            }
+            Node formNode = elementNode.getAttributes().getNamedItem(FORM);
+            if (formNode != null) {
+                return QUALIFIED.equals(formNode.getNodeValue());
+            }
+        }
+        return elementFormQualified;
+    }
+
     public String visitAttribute(Node attribute) throws Exception {
         StringBuilder builder = new StringBuilder();
         this.addImports(BALLERINA_XML_DATA_MODULE);
@@ -428,7 +459,7 @@ public class XSDVisitorImpl implements XSDVisitor {
         if (nameNode == null) {
             throw new Exception(String.format(ATTRIBUTE_NOT_FOUND_ERROR, NAME));
         }
-        if (attributeFormQualified) {
+        if (isAttributeQualified(attribute)) {
             builder.append(addNamespace(this, getTargetNamespace()));
         }
         builder.append(ATTRIBUTE_ANNOTATION).append(WHITESPACE);
@@ -719,7 +750,7 @@ public class XSDVisitorImpl implements XSDVisitor {
             } else if (childNode.getLocalName().equals(CHOICE)) {
                 stringBuilder.append(visit(new Choice(childNode)));
             } else {
-                if (elementFormQualified) {
+                if (isElementQualified(childNode)) {
                     stringBuilder.append(addNamespace(this, getTargetNamespace()));
                 }
                 if (childNode.hasChildNodes()) {
@@ -788,7 +819,7 @@ public class XSDVisitorImpl implements XSDVisitor {
             }
             order++;
             component.get().setOptional(isOptional);
-            if (elementFormQualified) {
+            if (isElementQualified(childNode)) {
                 stringBuilder.append(addNamespace(this, getTargetNamespace()));
             }
             String orderAnnotation = XMLDATA_ORDER + WHITESPACE + OPEN_BRACES + VALUE + COLON + order + CLOSE_BRACES;
@@ -828,7 +859,7 @@ public class XSDVisitorImpl implements XSDVisitor {
             }
             component.get().setSubType(true);
             component.get().setOptional(isOptional);
-            if (elementFormQualified) {
+            if (isElementQualified(childNode)) {
                 stringBuilder.append(addNamespace(this, getTargetNamespace()));
             }
             stringBuilder.append(component.get().accept(this));

--- a/xsd-core/src/test/java/io/ballerina/xsd/core/XSDToRecordTest.java
+++ b/xsd-core/src/test/java/io/ballerina/xsd/core/XSDToRecordTest.java
@@ -108,7 +108,11 @@ public class XSDToRecordTest {
             new Object[] {new String[] {"53_element_form_default_unqualified.xsd"},
                     "53_element_form_default_unqualified.bal"},
             new Object[] {new String[] {"54_complex_schema_unqualified.xsd"},
-                    "54_complex_schema_unqualified.bal"}
+                    "54_complex_schema_unqualified.bal"},
+            new Object[] {new String[] {"55_element_form_default_unqualified.xsd"},
+                    "55_element_form_default_unqualified.bal"},
+            new Object[] {new String[] {"56_attribute_form_default_qualified.xsd"},
+                    "56_attribute_form_default_qualified.bal"}
         );
     }
 

--- a/xsd-core/src/test/java/io/ballerina/xsd/core/XSDToRecordTest.java
+++ b/xsd-core/src/test/java/io/ballerina/xsd/core/XSDToRecordTest.java
@@ -104,7 +104,11 @@ public class XSDToRecordTest {
             new Object[] {new String[] {"51_sequence_with_unbounded_child_element.xsd"},
                     "51_sequence_with_unbounded_child_element.bal"},
             new Object[] {new String[] {"52_sequence_choice_with_min_occurs_zero.xsd"},
-                    "52_sequence_choice_with_min_occurs_zero.bal"}
+                    "52_sequence_choice_with_min_occurs_zero.bal"},
+            new Object[] {new String[] {"53_element_form_default_unqualified.xsd"},
+                    "53_element_form_default_unqualified.bal"},
+            new Object[] {new String[] {"54_complex_schema_unqualified.xsd"},
+                    "54_complex_schema_unqualified.bal"}
         );
     }
 

--- a/xsd-core/src/test/resources/expected/53_element_form_default_unqualified.bal
+++ b/xsd-core/src/test/resources/expected/53_element_form_default_unqualified.bal
@@ -1,0 +1,22 @@
+import ballerina/data.xmldata;
+
+@xmldata:Namespace {uri: "http://example.com/"}
+public type Person record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup sequenceGroup;
+|};
+
+@xmldata:Namespace {uri: "http://example.com/"}
+public type PersonElement record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup sequenceGroup;
+|};
+
+public type SequenceGroup record {|
+    @xmldata:SequenceOrder {value: 1}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string name;
+    @xmldata:SequenceOrder {value: 2}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    int age;
+|};

--- a/xsd-core/src/test/resources/expected/54_complex_schema_unqualified.bal
+++ b/xsd-core/src/test/resources/expected/54_complex_schema_unqualified.bal
@@ -1,0 +1,75 @@
+import ballerina/data.xmldata;
+
+@xmldata:Namespace {uri: "http://test.example.com/"}
+public enum StatusCode {
+    ACTIVE, INACTIVE, PENDING
+};
+
+@xmldata:Namespace {uri: "http://test.example.com/"}
+public type AgeType int;
+
+@xmldata:Namespace {uri: "http://test.example.com/"}
+public type AddressType record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup sequenceGroup;
+|};
+
+@xmldata:Namespace {uri: "http://test.example.com/"}
+public type ContactType record {|
+    @xmldata:Choice {minOccurs: 1, maxOccurs: 1}
+    ChoiceOption choiceOption;
+|};
+
+@xmldata:Namespace {uri: "http://test.example.com/"}
+public type PersonType record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup1 sequenceGroup1;
+    @xmldata:Attribute
+    string id;
+|};
+
+@xmldata:Namespace {uri: "http://test.example.com/"}
+public type Address record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup sequenceGroup;
+|};
+
+@xmldata:Namespace {uri: "http://test.example.com/"}
+public type Person record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup1 sequenceGroup1;
+    @xmldata:Attribute
+    string id;
+|};
+
+public type SequenceGroup record {|
+    @xmldata:SequenceOrder {value: 1}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string street;
+    @xmldata:SequenceOrder {value: 2}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string city;
+    @xmldata:SequenceOrder {value: 3}
+    @xmldata:Element {minOccurs: 0, maxOccurs: 1}
+    string zipCode?;
+|};
+
+public type ChoiceOption record {|
+    string email?;
+    string phone?;
+|};
+
+public type SequenceGroup1 record {|
+    @xmldata:SequenceOrder {value: 1}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string firstName;
+    @xmldata:SequenceOrder {value: 2}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string lastName;
+    @xmldata:SequenceOrder {value: 3}
+    @xmldata:Element {minOccurs: 0, maxOccurs: 1}
+    AgeType age?;
+    @xmldata:SequenceOrder {value: 4}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    StatusCode status;
+|};

--- a/xsd-core/src/test/resources/expected/55_element_form_default_unqualified.bal
+++ b/xsd-core/src/test/resources/expected/55_element_form_default_unqualified.bal
@@ -1,0 +1,76 @@
+import ballerina/data.xmldata;
+
+@xmldata:Namespace {uri: "http://example.com/library"}
+public type BookType record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup sequenceGroup;
+|};
+
+@xmldata:Namespace {uri: "http://example.com/library"}
+public type AuthorType record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup1 sequenceGroup1;
+|};
+
+@xmldata:Namespace {uri: "http://example.com/library"}
+public type LibraryType record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 65535}
+    SequenceGroup2[] sequenceGroup2;
+|};
+
+@xmldata:Namespace {uri: "http://example.com/library"}
+public type Book record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup sequenceGroup;
+|};
+
+@xmldata:Namespace {uri: "http://example.com/library"}
+public type Author record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup1 sequenceGroup1;
+|};
+
+@xmldata:Namespace {uri: "http://example.com/library"}
+public type Library record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 65535}
+    SequenceGroup2[] sequenceGroup2;
+|};
+
+public type SequenceGroup record {|
+    @xmldata:SequenceOrder {value: 1}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string title;
+    @xmldata:SequenceOrder {value: 2}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string author;
+    @xmldata:SequenceOrder {value: 3}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string isbn;
+    @xmldata:SequenceOrder {value: 4}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    int year;
+    @xmldata:SequenceOrder {value: 5}
+    @xmldata:Element {minOccurs: 0, maxOccurs: 1}
+    int pages?;
+|};
+
+public type SequenceGroup1 record {|
+    @xmldata:SequenceOrder {value: 1}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string firstName;
+    @xmldata:SequenceOrder {value: 2}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string lastName;
+    @xmldata:SequenceOrder {value: 3}
+    @xmldata:Element {minOccurs: 0, maxOccurs: 1}
+    int birthYear?;
+|};
+
+public type SequenceGroup2 record {|
+    @xmldata:SequenceOrder {value: 1}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string name;
+    @xmldata:SequenceOrder {value: 2}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 65535}
+    string[] book;
+|};

--- a/xsd-core/src/test/resources/expected/56_attribute_form_default_qualified.bal
+++ b/xsd-core/src/test/resources/expected/56_attribute_form_default_qualified.bal
@@ -1,0 +1,64 @@
+import ballerina/data.xmldata;
+
+@xmldata:Namespace {uri: "http://example.com/"}
+public type PersonType record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup sequenceGroup;
+    @xmldata:Namespace {uri: "http://example.com/"}
+    @xmldata:Attribute
+    string id;
+    @xmldata:Namespace {uri: "http://example.com/"}
+    @xmldata:Attribute
+    string version?;
+|};
+
+@xmldata:Namespace {uri: "http://example.com/"}
+public type AddressType record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup1 sequenceGroup1;
+    @xmldata:Namespace {uri: "http://example.com/"}
+    @xmldata:Attribute
+    string country;
+|};
+
+@xmldata:Namespace {uri: "http://example.com/"}
+public type Person record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup sequenceGroup;
+    @xmldata:Namespace {uri: "http://example.com/"}
+    @xmldata:Attribute
+    string id;
+    @xmldata:Namespace {uri: "http://example.com/"}
+    @xmldata:Attribute
+    string version?;
+|};
+
+@xmldata:Namespace {uri: "http://example.com/"}
+public type Address record {|
+    @xmldata:Sequence {minOccurs: 1, maxOccurs: 1}
+    SequenceGroup1 sequenceGroup1;
+    @xmldata:Namespace {uri: "http://example.com/"}
+    @xmldata:Attribute
+    string country;
+|};
+
+public type SequenceGroup record {|
+    @xmldata:SequenceOrder {value: 1}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string firstName;
+    @xmldata:SequenceOrder {value: 2}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string lastName;
+    @xmldata:SequenceOrder {value: 3}
+    @xmldata:Element {minOccurs: 0, maxOccurs: 1}
+    int age?;
+|};
+
+public type SequenceGroup1 record {|
+    @xmldata:SequenceOrder {value: 1}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string street;
+    @xmldata:SequenceOrder {value: 2}
+    @xmldata:Element {minOccurs: 1, maxOccurs: 1}
+    string city;
+|};

--- a/xsd-core/src/test/resources/xml/53_element_form_default_unqualified.xsd
+++ b/xsd-core/src/test/resources/xml/53_element_form_default_unqualified.xsd
@@ -1,0 +1,9 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="unqualified" targetNamespace="http://example.com/">
+    <xs:complexType name="Person">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+            <xs:element name="age" type="xs:int"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="PersonElement" type="Person"/>
+</xs:schema>

--- a/xsd-core/src/test/resources/xml/54_complex_schema_unqualified.xsd
+++ b/xsd-core/src/test/resources/xml/54_complex_schema_unqualified.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="unqualified" targetNamespace="http://test.example.com/">
+
+    <!-- Global simple type with enumeration -->
+    <xs:simpleType name="StatusCode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ACTIVE"/>
+            <xs:enumeration value="INACTIVE"/>
+            <xs:enumeration value="PENDING"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Global simple type with restriction -->
+    <xs:simpleType name="AgeType">
+        <xs:restriction base="xs:int"/>
+    </xs:simpleType>
+
+    <!-- Global complex type with sequence (local elements should have no namespace) -->
+    <xs:complexType name="AddressType">
+        <xs:sequence>
+            <xs:element name="street" type="xs:string"/>
+            <xs:element name="city" type="xs:string"/>
+            <xs:element name="zipCode" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Global complex type with choice (local elements should have no namespace) -->
+    <xs:complexType name="ContactType">
+        <xs:choice>
+            <xs:element name="email" type="xs:string"/>
+            <xs:element name="phone" type="xs:string"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <!-- Global complex type with sequence, custom types, and attribute -->
+    <xs:complexType name="PersonType">
+        <xs:sequence>
+            <xs:element name="firstName" type="xs:string"/>
+            <xs:element name="lastName" type="xs:string"/>
+            <xs:element name="age" type="AgeType" minOccurs="0"/>
+            <xs:element name="status" type="StatusCode"/>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <!-- Global elements -->
+    <xs:element name="Address" type="AddressType"/>
+    <xs:element name="Person" type="PersonType"/>
+
+</xs:schema>

--- a/xsd-core/src/test/resources/xml/55_element_form_default_unqualified.xsd
+++ b/xsd-core/src/test/resources/xml/55_element_form_default_unqualified.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/library"
+           elementFormDefault="unqualified">
+
+    <xs:complexType name="BookType">
+        <xs:sequence>
+            <xs:element name="title" type="xs:string"/>
+            <xs:element name="author" type="xs:string"/>
+            <xs:element name="isbn" type="xs:string"/>
+            <xs:element name="year" type="xs:int"/>
+            <xs:element name="pages" type="xs:int" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="AuthorType">
+        <xs:sequence>
+            <xs:element name="firstName" type="xs:string"/>
+            <xs:element name="lastName" type="xs:string"/>
+            <xs:element name="birthYear" type="xs:int" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="LibraryType">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+            <xs:element name="book" type="xs:string" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="Book" type="BookType"/>
+    <xs:element name="Author" type="AuthorType"/>
+    <xs:element name="Library" type="LibraryType"/>
+
+</xs:schema>

--- a/xsd-core/src/test/resources/xml/56_attribute_form_default_qualified.xsd
+++ b/xsd-core/src/test/resources/xml/56_attribute_form_default_qualified.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/"
+           elementFormDefault="unqualified"
+           attributeFormDefault="qualified">
+
+    <!-- Local elements should NOT have namespace (elementFormDefault=unqualified) -->
+    <!-- Local attributes SHOULD have namespace (attributeFormDefault=qualified) -->
+
+    <xs:complexType name="PersonType">
+        <xs:sequence>
+            <xs:element name="firstName" type="xs:string"/>
+            <xs:element name="lastName" type="xs:string"/>
+            <xs:element name="age" type="xs:int" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:string" use="required"/>
+        <xs:attribute name="version" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="AddressType">
+        <xs:sequence>
+            <xs:element name="street" type="xs:string"/>
+            <xs:element name="city" type="xs:string"/>
+        </xs:sequence>
+        <xs:attribute name="country" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:element name="Person" type="PersonType"/>
+    <xs:element name="Address" type="AddressType"/>
+
+</xs:schema>


### PR DESCRIPTION
## Purpose
> Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request adds support for the XSD root attributes elementFormDefault and attributeFormDefault to the XSD-to-Ballerina converter so generated Ballerina records respect XSD namespace qualification rules for elements and attributes.

### Key changes

- Core behavior
  - Parse elementFormDefault and attributeFormDefault from the root <xs:schema> and expose them as constants.
  - Extend XSDVisitor with setters/getters for element/attribute form-default state.
  - Implement form-default logic in XSDVisitorImpl so namespace annotations are emitted conditionally:
    - Element qualification is determined per-node (form="qualified" or ref) with a fallback to the schema-level elementFormDefault.
    - Attribute qualification prefers per-node form="qualified" and otherwise falls back to schema-level attributeFormDefault.
  - Apply targetNamespace and form-default initialization before processing child nodes and remove a duplicate targetNamespace call.

- Tests and fixtures
  - Add four XSD test fixtures and corresponding expected .bal outputs to validate:
    - Unqualified element handling across scenarios.
    - Qualified attribute handling when elements are unqualified.

- Project metadata
  - Bump project/version identifiers from 1.3.1 → 1.4.0 in gradle.properties, Ballerina.toml, Dependencies.toml, and BalTool.toml dependency paths.

### Outcome

Generated Ballerina types now align with XSD form-default semantics: local elements will not be annotated with the target namespace when elementFormDefault="unqualified", and local attributes will be annotated when attributeFormDefault="qualified". This change improves correctness of XML parsing/serialization by preventing mismatches between generated records and schema expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->